### PR TITLE
Bug Fix of Notes Application - Subject of Note allows to be updated 

### DIFF
--- a/src/domain/note.js
+++ b/src/domain/note.js
@@ -22,10 +22,8 @@ class Note {
 
     async update(note) {
         // Edited by CPang (Test 1 note subject allow update fix)
-        await this._note.update(
-            {body: note.body},
-            {updatedAt: note.updatedAt});
-
+        await this._note.update(note,
+            {fields:['body','updatedAt']});
     }
 
     async delete() {

--- a/src/domain/note.js
+++ b/src/domain/note.js
@@ -21,7 +21,11 @@ class Note {
     }
 
     async update(note) {
-        await this._note.update(note);
+        // Edited by CPang (Test 1 note subject allow update fix)
+        await this._note.update(
+            {body: note.body},
+            {updatedAt: note.updatedAt});
+
     }
 
     async delete() {

--- a/test/api/route/note.test.js
+++ b/test/api/route/note.test.js
@@ -88,6 +88,24 @@ describe('Tests for api route note', () => {
         });
     });
 
+    // Edited by CPang (Unit Test: Test 1 note subject allow update fix)
+    describe('update with note subject', () => {
+        it('should update a note without update the note subject, then json the exposed note', async () => {
+            req.note = note;
+            
+            // Note Subject is included, but the Note Subject should remain not updated after api update
+            req.body = {
+                subject: 'some subject updated',
+                body: 'some body',
+            };
+
+            await route.note.update(req, res);
+
+            req.note.update.calledWithExactly(req.body).should.be.true();
+            res.json.calledWithExactly('exposedNote').should.be.true();
+        });
+    });
+
     describe('delete', () => {
         it('should delete a note then send 204 status', async () => {
             req.note = note;

--- a/test/domain/note.test.js
+++ b/test/domain/note.test.js
@@ -58,6 +58,24 @@ describe('Tests for domain Note', () => {
             });
         });
 
+        // Edited by CPang (Unit Test: Test 1 note subject allow update fix)
+        describe('update with subject', () => {
+            it('should update the body of the note without update note subject', async () => {
+                await domainNote.update({
+                    subject: 'some subject updated',
+                    body: 'new body'
+                });
+
+                // The subject of the note should remain not updated
+                domainNote.expose().should.match({
+                    id: noteId,
+                    subject: 'some subject',
+                    body: 'new body',
+                    updatedAt: _.isDate,
+                });
+            });
+        });
+
         describe('delete', () => {
             it('should delete the note', async () => {
                 await domainNote.delete();


### PR DESCRIPTION
Bug Fix of Notes Application - Subject of Note allows to be updated

## Description
This pull request is related to the bug issue stated in Skill Test 1 - Subject of Note allows to be updated in the Notes Application.
Even though the Web app tries to prohibit you from modifying a subject of an existing note, there is a bug that allows you to modify a subject.

Steps to reproduce the bug issue:
In the original source code of the Notes Application, there are the following steps to track the bug issue, i.e.
1. The note object attributes is defined in the /model/note.js source code. By using the Sequelize library, the note object attributes is defined (id, subject, body)
2. In the backend source code, an existing note can be updated by the configured api path, i.e. 
'/notes/:noteId' (HTTP PUT method)
3. The request body setting to update existing note using the '/notes/:noteId' (HTTP PUT method) api is configured in the /route/note.js source code.
```
module.exports.update = async (req, res) => {
    await req.note.update(req.body);
    res.json(req.note.expose());
};
```
The body and subject attributes of note are possible to be included in the request body.
4. The note update function of note PUT api is executed based on the async update(note) function stated in  /domain/note.js source code, i.e.
```
    async update(note) {
        await this._note.update(note);
    }
```
5. The note object attributes is updated by the update() method stated in the Sequelize library, i.e.
[Sequelize model update method reference](http://docs.sequelizejs.com/class/lib/model.js~Model.html#static-method-update )
In the original source code, the scope of which note object attributes to be updated is not specified in the  async update function.
```
    async update(note) {
        await this._note.update(note);
    }
```
If the ```note``` object stated above included the subject attribute, the subject attribute of note can be updated.
It can be the cause of allow note subject to update issue.
6. Based on the update() method reference of Sequelize library, all of the note attributes can allow to be updated unless specified attributes is stated in the parameters of the update() method.
In order to restrict not to update the subject attribute, the note attributes fields to be updated need to specify in the update() method, one of the ways to limit attributes can be:
```
    async update(note) {
        // Edited by CPang (Test 1 note subject allow update fix)
        await this._note.update(note,
            {fields:['body','updatedAt']});
    }
```
As stated in the fix above, only body and updatedAt attributes of note object can allow to be updated.

## Related Issue
Other problems this bug might cause may include, i.e.:
1. Since in the original source code, all of the attributes included in the note element of ```async update(note)``` method are possible to be updated, if the attributes of note object are increased in the future versions of the note application (e.g. an additional 'Remark' attribute is added to the note object), it is possible that other newly added note attributes can be updated, if the other source code parts related to the note update function(e.g. frontend) had not designed to target the note object not to update these newly added note attributes.
2. As stated in point 1 above, if the note application is further developed in the future, other source code parts related to the note update function (e.g.) needs to carefully design to prevent update other newly added note attributes that are not targeted to be updated.
This increases development cost and time.

## Code Structure
Fundamental problems in the code structure that allows this kind of bugs exist may include, i.e.:
1. In the original source code, the backend has applied the Sequelize library model update() method, in order to update the note object attributes. However, the developer has not carefully designed the update() method in writing the update note object attributes method. The [Sequelize model update method reference](http://docs.sequelizejs.com/class/lib/model.js~Model.html#static-method-update ) should be referred before implementation. Which attributes values to be updated in the update method parameter is one of the initial design considerations.
2. The note PUT api ('/notes/:noteId' (HTTP PUT method)) should be designed more carefully.
In the original source code of note PUT api, all data included in the request body are possible to be included to execute the update note function. The request body may be designed to filter out to process only specific data written in the request body before execute the update note function.
For example, use a swagger.yml to specify particular input parameters to be process in the note PUT api. And then modify the related functions related to note PUT api to process the input parameters specified in the request body of note PUT api only.

## Propositions to fix the bug
Proposition One:
In the /domain/note.js backend source code, specify in the update(note) method not to update the subject attribute value, i.e.
```
    async update(note) {
        // Edited by CPang (Test 1 note subject allow update fix)
        await this._note.update(
            {body: note.body},
            {updatedAt: note.updatedAt});

    }
```
Pros:
1. The scope of attribute values to be updated are clearly specified.
2. As the note attribute value parameter is fixed in the update() method, accidental update of other note attribute values can be prevented.

Cons:
1. The scope of attribute values to be updated is hard-coded in the update() method, it affects the flexibility to update other note attribute values if the note application is further developed in the future. 
2. The update() method cannot dynamically update note attribute values. It affects the efficiency, time and cost of future development of the note application.


Proposition Two:
In the /domain/note.js backend source code, use the fields parameter of the Sequelize model update method to limit the fields to update, i.e.
```
    async update(note) {
        // Edited by CPang (Test 1 note subject allow update fix)
        await this._note.update(note,
            {fields:['body','updatedAt']});
    }
```
[Sequelize model update method reference](http://docs.sequelizejs.com/class/lib/model.js~Model.html#static-method-update )
fields parameter
By limiting the fields to ['body','updatedAt'] of the note attribute fields only, the note PUT api will only update the ['body','updatedAt'] fields when executing the update()method.

Pros:
1. By using the fields parameter of the Sequelize model update method, if there are more note attributes need to be updated in the future development, the note attribute fields to update can be simply added to array of the fields parameter of the Sequelize model update method.
2. The attribute values parameter in the Sequelize model update method is not hard-coded as Proposition One. It is more easier to manage the update method code as the attribute values parameter is dynamically updated.

Cons:
1. If there are attributes fields newly added/deleted in the future development of the note application, as the fields parameter of the Sequelize model update method is hard-coded, it affects efficiency, time and cost to manage this part of source code in future development.
2. The fields parameter of the Sequelize model update method required developer to input string arrays to specify attribute field names. Auto-completion of attribute field names in IDE (e.g. VS Code) can not be done. If the attribute field names are inputted incorrectly accidentally, the update method() cannot be executed as expected. 

Proposition to choose: Proposition Two
Reason:
1. Compared to Proposition One, the attribute value parameter of the Sequelize model update method is not hard-coded, i.e. dynamically updated. It improves the code efficiency to manage and reuse.
2. Compared to Proposition One, developers can be relatively more easier to manage this part of source code. The scope of which note attribute fields to be updated can be adjusted by simply modifying the string array specified in the fields parameter of the Sequelize model update method.

## Unit Test
Two unit test functions are added in the bug fix related to the note allow update subject issue, i.e.
1. test/api/route/note.test.js
```
    // Edited by CPang (Unit Test: Test 1 note subject allow update fix)
    describe('update with note subject', () => {
        it('should update a note without update the note subject, then json the exposed note', async () => {
            req.note = note;

            // Note Subject is included, but the Note Subject should remain not updated after api update
            req.body = {
                subject: 'some subject updated',
                body: 'some body',
            };

            await route.note.update(req, res);

            req.note.update.calledWithExactly(req.body).should.be.true();
            res.json.calledWithExactly('exposedNote').should.be.true();
        });
    });
```

2. test/domain/note.test.js
```
        // Edited by CPang (Unit Test: Test 1 note subject allow update fix)
        describe('update with subject', () => {
            it('should update the body of the note without update note subject', async () => {
                await domainNote.update({
                    subject: 'some subject updated',
                    body: 'new body'
                });

                // The subject of the note should remain not updated
                domainNote.expose().should.match({
                    id: noteId,
                    subject: 'some subject',
                    body: 'new body',
                    updatedAt: _.isDate,
                });
            });
        });
```

Although the note subject is set as 'some subject updated', the expected result of updated note would expect the note subject to be not updated, i.e. 'some subject', as set in the original note attribute values.

## Checklist (Completed stage)
- [x] Design
- [x] Coding
- [x] Debug
- [x] Unit Test
- [x] Documentation

